### PR TITLE
Change emote from 88->99.

### DIFF
--- a/DozeAnywhere/Plugin.cs
+++ b/DozeAnywhere/Plugin.cs
@@ -45,7 +45,7 @@ public sealed class Plugin : IDalamudPlugin
 			"/xdoze",
 			GetExecuteEmotionCommand(
 				13,
-				88,
+				99,
 				"Use default /doze emote and «doze anywhere» if ALT is pressed."));
 
 		CommandManager.AddHandler(
@@ -76,7 +76,7 @@ public sealed class Plugin : IDalamudPlugin
 				commandId = 96;
 				break;
 			case "doze":
-				commandId = 88;
+				commandId = 99;
 				break;
 			default:
 				ChatGui.PrintError("First argument should be either «sit» or «doze»!");


### PR DESCRIPTION
Emote 99 stops snapping to the bed grid.
Emote 88 snaps to the bed grid. Not sure if this is intended with the plugin, but I feel removing more snapping is more apt to the name "DozeAnywhere" instead of "DozeAnywhere unless you are already on a bed"